### PR TITLE
fix(ci): seed example token secret for automated E2E runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,8 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: E2E tests
+        env:
+          GUIDEKIT_SECRET: guidekit-example-e2e-secret-32-chars
         run: npx playwright test
 
       - name: Dependency audit

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const E2E_GUIDEKIT_SECRET =
+  process.env.GUIDEKIT_SECRET ?? 'guidekit-example-e2e-secret-32-chars';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -28,6 +31,10 @@ export default defineConfig({
 
   webServer: {
     command: 'pnpm --filter @guidekit/example-nextjs dev',
+    env: {
+      ...process.env,
+      GUIDEKIT_SECRET: E2E_GUIDEKIT_SECRET,
+    },
     url: 'http://localhost:3099',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
## Summary
- seed a deterministic `GUIDEKIT_SECRET` in the Playwright web server when the shell does not provide one
- pass the same secret explicitly in Nightly before `npx playwright test`
- keep the change scoped to automated E2E execution so the example app still requires explicit secrets outside the test harness

## Checks
- `unset GUIDEKIT_SECRET; pnpm exec playwright test e2e/widget.spec.ts --project=example-nextjs --workers=1`
- `unset GUIDEKIT_SECRET; pnpm exec playwright test e2e/accessibility.spec.ts --project=example-nextjs --workers=1`

## Release Notes
- internal-only CI/test-harness fix; no changeset required

Refs #9