### PR TITLE
feat: close remaining open GitHub issue backlog

### DIFF
--- a/.changeset/green-berries-grow.md
+++ b/.changeset/green-berries-grow.md
@@ -1,0 +1,6 @@
+---
+"@guidekit/react": minor
+"@guidekit/core": minor
+---
+
+Add a configurable `theme.zIndex` option to `GuideKitProvider` theme settings so host apps can control widget stacking while preserving the default high z-index.

--- a/.changeset/odd-rabbits-repeat.md
+++ b/.changeset/odd-rabbits-repeat.md
@@ -1,0 +1,5 @@
+---
+"@guidekit/cli": minor
+---
+
+Extend `guidekit doctor` with GuideKit monorepo parity diagnostics for hosted PR E2E coverage, example-app token-route alignment, and Nightly dependency-audit enforcement.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-and-test
     steps:
       - uses: actions/checkout@v4
@@ -67,6 +66,8 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run E2E tests
+        env:
+          GUIDEKIT_SECRET: guidekit-example-e2e-secret-32-chars
         run: pnpm test:e2e
 
       - name: Upload test results

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
         run: npx playwright test
 
       - name: Dependency audit
-        run: pnpm audit --prod || true
+        run: pnpm audit --prod
 
       - name: Upload test results
         if: failure()

--- a/README.md
+++ b/README.md
@@ -47,14 +47,19 @@ Existing solutions fall short:
 
 ## Packages
 
-| Package | Description | Size (gz) |
-|---------|-------------|-----------|
-| [`@guidekit/core`](./packages/core) | Core engine — DOM intelligence, LLM orchestration, context management | 64.93 KB |
-| [`@guidekit/react`](./packages/react) | React bindings — Provider, hooks, Shadow DOM widget | 7.73 KB |
-| [`@guidekit/server`](./packages/server) | Server utilities — token generation, session management | 1.81 KB |
-| [`@guidekit/vanilla`](./packages/vanilla) | Vanilla JS — IIFE bundle for non-React apps | 92.36 KB |
-| [`@guidekit/vad`](./packages/vad) | Voice Activity Detection — Silero ONNX model | 22.8 KB |
-| [`@guidekit/cli`](./packages/cli) | CLI — `init`, `doctor`, `generate-secret` | 4.83 KB |
+| Package | Version | Role | Audience | Status |
+|---------|---------|------|----------|--------|
+| [`@guidekit/core`](./packages/core) | `0.2.0` | DOM intelligence, orchestration, context, rendering primitives | Every app integration | Core |
+| [`@guidekit/react`](./packages/react) | `0.2.0` | Provider, hooks, Shadow DOM widget | React / Next.js apps | Core |
+| [`@guidekit/server`](./packages/server) | `0.2.0` | Token generation, auth middleware, session helpers | Server runtimes backing GuideKit clients | Core |
+| [`@guidekit/vanilla`](./packages/vanilla) | `0.1.1` | Script-tag and framework-agnostic browser integration | Non-React apps and simple embeds | Stable optional |
+| [`@guidekit/vad`](./packages/vad) | `0.1.1` | Voice activity detection model and helpers | Voice-enabled experiences | Optional voice |
+| [`@guidekit/cli`](./packages/cli) | `0.1.1` | `init`, `doctor`, `generate-secret` | Local setup, contributor diagnostics, CI parity checks | Optional DX |
+| [`@guidekit/intelligence`](./packages/intelligence) | `0.1.1` | Semantic page intelligence engine | Advanced understanding and ranking pipelines | Advanced optional |
+| [`@guidekit/knowledge`](./packages/knowledge) | `0.1.1` | Knowledge retrieval with BM25 / TF-IDF search | Retrieval-augmented guidance | Advanced optional |
+| [`@guidekit/plugins`](./packages/plugins) | `0.1.1` | Plugin system and extension hooks | Custom platform extensions and partner integrations | Advanced optional |
+
+Version numbers do not move in lockstep. `0.2.0` packages are the default integration path today; `0.1.1` packages are stable optional surfaces or advanced building blocks that can evolve on their own cadence.
 
 ## Quick Start
 

--- a/apps/docs/app/docs/cli/page.mdx
+++ b/apps/docs/app/docs/cli/page.mdx
@@ -35,7 +35,7 @@ npx guidekit init
 
 ### `guidekit doctor`
 
-Validates your setup — checks environment variables, packages, and provider connectivity.
+Validates your setup — checks environment variables, packages, provider connectivity, and, when run inside the GuideKit monorepo, CI/local parity for the example app and release-confidence workflows.
 
 ```bash
 npx guidekit doctor
@@ -49,6 +49,7 @@ npx guidekit doctor
 - `STT_API_KEY` and `TTS_API_KEY` (optional, for voice)
 - `@guidekit/core`, `@guidekit/react`, `@guidekit/server` are installed
 - Connectivity to Google AI, Deepgram, and ElevenLabs APIs
+- In the GuideKit monorepo, example-app token-route parity, hosted PR E2E coverage, and the Nightly dependency-audit gate
 
 **Example output:**
 ```

--- a/apps/docs/app/docs/provider/page.mdx
+++ b/apps/docs/app/docs/provider/page.mdx
@@ -73,6 +73,17 @@ options={{
 }}
 ```
 
+### Theme
+
+```tsx
+theme={{
+  primaryColor: '#4a9eed',
+  borderRadius: '20px',
+  position: 'bottom-right',
+  zIndex: 1000, // default: 2147483647
+}}
+```
+
 ### Callbacks
 
 ```tsx

--- a/apps/docs/app/page.mdx
+++ b/apps/docs/app/page.mdx
@@ -36,14 +36,19 @@ That's it. GuideKit auto-discovers your site, builds a page model, and provides 
 
 ## Packages
 
-| Package | Size (gzip) | Description |
-|---------|------------|-------------|
-| `@guidekit/core` | 60 KB | DOM scanner, LLM orchestrator, voice pipeline, visual guidance |
-| `@guidekit/react` | 7 KB | Provider, hooks, Shadow DOM widget |
-| `@guidekit/server` | 2 KB | JWT token generation, session management |
-| `@guidekit/vanilla` | 88 KB | IIFE bundle for non-React apps |
-| `@guidekit/cli` | 5 KB | CLI tools (init, doctor, generate-secret) |
-| `@guidekit/vad` | 800 KB | Silero VAD model (optional, voice only) |
+| Package | Version | Audience | What it is | Status |
+|---------|---------|----------|------------|--------|
+| `@guidekit/core` | `0.2.0` | Every integration | DOM scanner, orchestration, voice pipeline, visual guidance primitives | Core |
+| `@guidekit/react` | `0.2.0` | React / Next.js apps | Provider, hooks, Shadow DOM widget | Core |
+| `@guidekit/server` | `0.2.0` | Backend token endpoints | JWT token generation and session helpers | Core |
+| `@guidekit/vanilla` | `0.1.1` | Non-React apps | IIFE bundle and framework-agnostic browser integration | Stable optional |
+| `@guidekit/cli` | `0.1.1` | Local setup and contributors | CLI tools for init, doctor, secrets, and parity diagnostics | Optional DX |
+| `@guidekit/vad` | `0.1.1` | Voice experiences | Silero VAD model and helpers | Optional voice |
+| `@guidekit/intelligence` | `0.1.1` | Advanced guide reasoning | Semantic page intelligence engine | Advanced optional |
+| `@guidekit/knowledge` | `0.1.1` | Retrieval-augmented guidance | Knowledge search and indexing utilities | Advanced optional |
+| `@guidekit/plugins` | `0.1.1` | Extension authors | Plugin system and extension hooks | Advanced optional |
+
+GuideKit packages release independently. The `0.2.0` track is the recommended default surface today, while `0.1.1` packages represent optional or advanced capabilities that are intentionally versioned on their own cadence.
 
 ## Key Features
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1113,6 +1113,90 @@ describe('doctor — summary output', () => {
     const output = allOutput();
     expect(output).toContain('warning');
   });
+
+  it('shows GuideKit repo parity checks when running inside the monorepo', async () => {
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      return [
+        path.join('/project', 'package.json'),
+        path.join('/project', '.env.local'),
+        path.join('/project', '.gitignore'),
+        path.join('/project', 'apps', 'example-nextjs', 'app', 'api', 'guidekit', 'token', 'route.ts'),
+        path.join('/project', '.github', 'workflows', 'nightly.yml'),
+        path.join('/project', '.github', 'workflows', 'ci.yml'),
+        path.join('/project', 'playwright.config.ts'),
+      ].includes(s);
+    });
+    mockReadFileSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith('.gitignore')) return '.env\nnode_modules\n';
+      if (s.endsWith(path.join('api', 'guidekit', 'token', 'route.ts'))) {
+        return "export async function POST(){ const secret = process.env.GUIDEKIT_SECRET; return secret ? Response.json({ ok: true }) : Response.json({ ok: false }); }";
+      }
+      if (s.endsWith('nightly.yml')) {
+        return "name: Nightly\n- name: Dependency audit\n  run: pnpm audit --prod\n- name: E2E tests\n  env:\n    GUIDEKIT_SECRET: guidekit-example-e2e-secret-32-chars\n";
+      }
+      if (s.endsWith('ci.yml')) {
+        return "on:\n  pull_request:\n    branches: [main]\njobs:\n  e2e:\n    name: E2E Tests\n";
+      }
+      if (s.endsWith('playwright.config.ts')) {
+        return "const E2E_GUIDEKIT_SECRET = process.env.GUIDEKIT_SECRET ?? 'guidekit-example-e2e-secret-32-chars';\nconst cfg = { webServer: { env: { GUIDEKIT_SECRET: E2E_GUIDEKIT_SECRET } } };";
+      }
+      return JSON.stringify({
+        dependencies: {
+          '@guidekit/core': '^1.0.0',
+          '@guidekit/react': '^1.0.0',
+          '@guidekit/server': '^1.0.0',
+        },
+      });
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    process.env.GUIDEKIT_SECRET = 'a'.repeat(32);
+    process.env.LLM_API_KEY = 'AIabcdefghijklmnopqrstuvwxyz';
+
+    const { runDoctor } = await import('./commands/doctor.js');
+    await runDoctor();
+    const output = allOutput();
+    expect(output).toContain('GuideKit Repo Parity');
+    expect(output).toContain('Hosted E2E signal');
+    expect(output).toContain('Nightly dependency audit gate');
+  });
+
+  it('warns when hosted E2E signal is missing for pull requests', async () => {
+    mockExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      return [
+        path.join('/project', 'package.json'),
+        path.join('/project', 'apps', 'example-nextjs', 'app', 'api', 'guidekit', 'token', 'route.ts'),
+        path.join('/project', '.github', 'workflows', 'nightly.yml'),
+        path.join('/project', '.github', 'workflows', 'ci.yml'),
+        path.join('/project', 'playwright.config.ts'),
+      ].includes(s);
+    });
+    mockReadFileSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith(path.join('api', 'guidekit', 'token', 'route.ts'))) {
+        return "export async function POST(){ const secret = process.env.GUIDEKIT_SECRET; return secret ? Response.json({ ok: true }) : Response.json({ ok: false }); }";
+      }
+      if (s.endsWith('nightly.yml')) {
+        return "run: pnpm audit --prod || true\nenv:\n  GUIDEKIT_SECRET: guidekit-example-e2e-secret-32-chars\n";
+      }
+      if (s.endsWith('ci.yml')) {
+        return "jobs:\n  e2e:\n    name: E2E Tests\n    if: github.event_name == 'push' && github.ref == 'refs/heads/main'\n";
+      }
+      if (s.endsWith('playwright.config.ts')) {
+        return "const E2E_GUIDEKIT_SECRET = process.env.GUIDEKIT_SECRET ?? 'guidekit-example-e2e-secret-32-chars';\nconst cfg = { webServer: { env: { GUIDEKIT_SECRET: E2E_GUIDEKIT_SECRET } } };";
+      }
+      return JSON.stringify({ dependencies: {} });
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+
+    const { runDoctor } = await import('./commands/doctor.js');
+    await runDoctor();
+    const output = allOutput();
+    expect(output).toContain('Pull requests do not currently get a hosted E2E signal');
+    expect(output).toContain('Nightly is not enforcing the production dependency audit exit code');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -164,6 +164,72 @@ async function checkProviderConnectivity(
   }
 }
 
+function checkGuideKitRepoParity(root: string): CheckResult[] {
+  const tokenRoutePath = path.join(root, 'apps', 'example-nextjs', 'app', 'api', 'guidekit', 'token', 'route.ts');
+  const nightlyWorkflowPath = path.join(root, '.github', 'workflows', 'nightly.yml');
+  const ciWorkflowPath = path.join(root, '.github', 'workflows', 'ci.yml');
+  const playwrightConfigPath = path.join(root, 'playwright.config.ts');
+
+  if (
+    !fileExists(tokenRoutePath) ||
+    !fileExists(nightlyWorkflowPath) ||
+    !fileExists(ciWorkflowPath) ||
+    !fileExists(playwrightConfigPath)
+  ) {
+    return [];
+  }
+
+  const tokenRoute = readFile(tokenRoutePath);
+  const nightlyWorkflow = readFile(nightlyWorkflowPath);
+  const ciWorkflow = readFile(ciWorkflowPath);
+  const playwrightConfig = readFile(playwrightConfigPath);
+
+  const routeRequiresSecret = tokenRoute.includes('process.env.GUIDEKIT_SECRET');
+  const nightlySeedsSecret =
+    nightlyWorkflow.includes('GUIDEKIT_SECRET: guidekit-example-e2e-secret-32-chars');
+  const playwrightSeedsSecret =
+    playwrightConfig.includes('const E2E_GUIDEKIT_SECRET') &&
+    playwrightConfig.includes('GUIDEKIT_SECRET: E2E_GUIDEKIT_SECRET');
+  const ciRunsE2EOnPullRequests =
+    ciWorkflow.includes('pull_request:') &&
+    ciWorkflow.includes('name: E2E Tests') &&
+    !ciWorkflow.includes("if: github.event_name == 'push' && github.ref == 'refs/heads/main'");
+  const nightlyAuditBlocks =
+    nightlyWorkflow.includes('pnpm audit --prod') &&
+    !nightlyWorkflow.includes('pnpm audit --prod || true');
+
+  const parityIssues: string[] = [];
+  if (!routeRequiresSecret) parityIssues.push('token route no longer enforces GUIDEKIT_SECRET');
+  if (!nightlySeedsSecret) parityIssues.push('Nightly does not seed a deterministic test secret');
+  if (!playwrightSeedsSecret) parityIssues.push('Playwright webServer does not seed a deterministic test secret');
+
+  const results: CheckResult[] = [
+    {
+      name: 'GuideKit repo parity',
+      status: parityIssues.length === 0 ? 'ok' : 'warn',
+      message: parityIssues.length === 0
+        ? 'Example token route and automated E2E secret seeding are aligned for local and CI parity.'
+        : `Repo parity gaps: ${parityIssues.join('; ')}`,
+    },
+    {
+      name: 'Hosted E2E signal',
+      status: ciRunsE2EOnPullRequests ? 'ok' : 'warn',
+      message: ciRunsE2EOnPullRequests
+        ? 'Pull requests receive a hosted E2E signal before release-confidence fixes are merged.'
+        : 'Pull requests do not currently get a hosted E2E signal.',
+    },
+    {
+      name: 'Nightly dependency audit gate',
+      status: nightlyAuditBlocks ? 'ok' : 'warn',
+      message: nightlyAuditBlocks
+        ? 'Nightly fails when production dependency advisories are detected.'
+        : 'Nightly is not enforcing the production dependency audit exit code.',
+    },
+  ];
+
+  return results;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -196,6 +262,12 @@ export async function runDoctor(): Promise<void> {
   results.push(await checkProviderConnectivity('Google AI', 'https://generativelanguage.googleapis.com'));
   results.push(await checkProviderConnectivity('Deepgram', 'https://api.deepgram.com'));
   results.push(await checkProviderConnectivity('ElevenLabs', 'https://api.elevenlabs.io'));
+
+  const repoParityChecks = checkGuideKitRepoParity(root);
+  if (repoParityChecks.length > 0) {
+    log(`${c.bold}GuideKit Repo Parity${c.reset}`);
+    results.push(...repoParityChecks);
+  }
 
   // Print results
   log('');

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -450,6 +450,8 @@ export interface GuideKitTheme {
   primaryColor?: string;
   position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
   borderRadius?: string;
+  /** Widget host z-index. Defaults to 2147483647 when omitted. */
+  zIndex?: number | string;
   /** Color scheme: 'light', 'dark', or 'auto' (respects prefers-color-scheme). Default: 'light'. */
   colorScheme?: 'light' | 'dark' | 'auto';
   /** CSS custom property overrides for fine-grained theming. */

--- a/packages/react/src/hooks.test.tsx
+++ b/packages/react/src/hooks.test.tsx
@@ -17,6 +17,7 @@ import {
 import type { GuideKitErrorType, MockActions } from './testing.js';
 
 import {
+  GuideKitProvider,
   useGuideKitStatus,
   useGuideKitVoice,
   useGuideKitActions,
@@ -452,6 +453,30 @@ describe('GuideKitProvider', () => {
     return initPromise.catch(() => {}).then(() => {
       expect(onError).toHaveBeenCalledWith(initError);
     });
+  });
+
+  it('applies theme.zIndex to the widget host', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        React.createElement(
+          GuideKitProvider,
+          {
+            tokenEndpoint: '/api/guidekit/token',
+            onError: () => {},
+            theme: { zIndex: 1234 },
+          },
+          React.createElement('span', null, 'mounted'),
+        ),
+      );
+    });
+
+    const widgetHost = container.querySelector('#guidekit-widget') as HTMLDivElement | null;
+    expect(widgetHost).toBeTruthy();
+    expect(widgetHost?.style.zIndex).toBe('1234');
   });
 });
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1132,6 +1132,7 @@ interface WidgetProps {
     primaryColor?: string;
     position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
     borderRadius?: string;
+    zIndex?: number | string;
   };
   consentRequired?: boolean;
   instanceId?: string;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -501,7 +501,7 @@ const WIDGET_STYLES = /* css */ `
     all: initial;
     font-family: var(--gk-font);
     position: fixed;
-    z-index: 2147483647;
+    z-index: var(--gk-z-index, 2147483647);
     bottom: 24px;
     right: 24px;
   }
@@ -1231,6 +1231,11 @@ function GuideKitWidget({ theme, consentRequired, instanceId }: WidgetProps) {
     if (theme?.borderRadius) {
       host.style.setProperty('--gk-radius', theme.borderRadius);
     }
+    if (theme?.zIndex !== undefined) {
+      host.style.setProperty('--gk-z-index', String(theme.zIndex));
+    } else {
+      host.style.removeProperty('--gk-z-index');
+    }
 
     // Position
     const pos = theme?.position ?? 'bottom-right';
@@ -1681,7 +1686,7 @@ function GuideKitWidget({ theme, consentRequired, instanceId }: WidgetProps) {
         // The host element itself is positioned via :host in Shadow DOM CSS,
         // but we also set fixed positioning here as a fallback.
         position: 'fixed',
-        zIndex: 2147483647,
+        zIndex: theme?.zIndex ?? 2147483647,
         bottom: '24px',
         right: '24px',
         // Ensure the host doesn't interfere with page layout


### PR DESCRIPTION
## Summary
- add configurable `theme.zIndex` support for the React widget with docs and tests
- extend `guidekit doctor` with GuideKit monorepo parity diagnostics for hosted PR E2E coverage and nightly audit enforcement
- require hosted PR E2E coverage in CI and make Nightly fail on production dependency advisories
- publish a full package capability/version matrix across the README and docs home
- record the remaining backlog closure work in one PR

## Checks
- `pnpm install --frozen-lockfile`
- `pnpm audit --prod`
- `pnpm exec vitest run packages/cli/src/cli.test.ts packages/react/src/hooks.test.tsx`
- `pnpm typecheck`
- `pnpm exec playwright test e2e/widget.spec.ts e2e/accessibility.spec.ts --project=example-nextjs --workers=1`
- `pnpm lint` (warnings only; no new lint errors)

Closes #8
Closes #11
Closes #12
Closes #13
Closes #15